### PR TITLE
Add !default to hamburger variables

### DIFF
--- a/sass/_components.hamburger.scss
+++ b/sass/_components.hamburger.scss
@@ -1,17 +1,17 @@
 /* -----------------------------------------------------------------------------
 
   HAMBURGER ICONS COMPONENT
-  
+
 ----------------------------------------------------------------------------- */
 
 // vars
 
-$button-width: 96px;                    // The width of the button area
-$button-height: 96px;                   // The height of the button area
-$bar-thickness: 8px;                    // The thickness of the button bars
-$button-pad: 18px;                      // The left/right padding between button area and bars.
-$button-bar-space: 12px;                // The spacing between button bars
-$button-transistion-duration: 0.3s;     // The transition duration
+$button-width: 96px !default;                    // The width of the button area
+$button-height: 96px !default;                   // The height of the button area
+$bar-thickness: 8px !default;                    // The thickness of the button bars
+$button-pad: 18px !default;                      // The left/right padding between button area and bars.
+$button-bar-space: 12px !default;                // The spacing between button bars
+$button-transistion-duration: 0.3s !default;     // The transition duration
 
 /**
  * Toggle Switch Globals
@@ -101,7 +101,7 @@ $button-transistion-duration: 0.3s;     // The transition duration
 
 /**
  * Style 2
- * 
+ *
  * Hamburger to "x" (htx). Takes on a hamburger shape, bars slide
  * down to center and transform into an "x".
  */
@@ -171,7 +171,7 @@ $button-transistion-duration: 0.3s;     // The transition duration
 
 .c-hamburger--htla span::before,
 .c-hamburger--htla span::after {
-  
+
 }
 
 .c-hamburger--htla span::before {
@@ -213,7 +213,7 @@ $button-transistion-duration: 0.3s;     // The transition duration
  * Style 4
  *
  * Hamburger to right-arrow (htra). Hamburger menu transforms to a
- * right-pointing arrow. Usually indicates an off canvas menu sliding in from 
+ * right-pointing arrow. Usually indicates an off canvas menu sliding in from
  * right that will be close on re-click of the icon.
  */
 
@@ -227,7 +227,7 @@ $button-transistion-duration: 0.3s;     // The transition duration
 
 .c-hamburger--htra span::before,
 .c-hamburger--htra span::after {
-  
+
 }
 
 .c-hamburger--htra span::before {


### PR DESCRIPTION
Added !default to the block of variables for hamburger icons to allow overwriting from a reset file. This enables user to customize the styling in a way that won't get overwritten if they update using a package manager like Bower.
